### PR TITLE
Optimize host fitting

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -119,7 +119,7 @@ traccc_add_library( traccc_core core TYPE SHARED
   "src/ambiguity_resolution/greedy_ambiguity_resolution_algorithm.cpp" )
 target_link_libraries( traccc_core
   PUBLIC Eigen3::Eigen vecmem::core detray::core detray::detectors
-         traccc::algebra ActsCore )
+        traccc::algebra ActsCore TBB::tbb )
 
 # Prevent Eigen from getting confused when building code for a
 # CUDA or HIP backend with SYCL.


### PR DESCRIPTION
## Summary
- parallelize host track fitting using TBB
- link `traccc_core` with `TBB::tbb`
- fix narrowing warnings when indexing device vectors

## Testing
- `pre-commit run --files core/include/traccc/fitting/details/fit_tracks.hpp core/CMakeLists.txt`
- `cmake --preset host-fp32 -S . -B build` *(fails: Could NOT find TBB)*

------
https://chatgpt.com/codex/tasks/task_e_68404ed05174832093ae368001b48cc2