### PR TITLE
Add configurable CUDA block size for fitting

### DIFF
--- a/core/include/traccc/fitting/fitting_config.hpp
+++ b/core/include/traccc/fitting/fitting_config.hpp
@@ -35,6 +35,10 @@ struct fitting_config {
     std::size_t min_barcode_sequence_capacity = 100;
     traccc::scalar backward_filter_mask_tolerance =
         5.f * traccc::unit<scalar>::mm;
+
+    /// Number of CUDA threads per block used by the fitting kernel.
+    /// A value of 0 selects the implementation default.
+    unsigned int threads_per_block = 0;
 };
 
 }  // namespace traccc

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -98,7 +98,8 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
     // Calculate the number of threads and thread blocks to run the track
     // fitting
     if (n_tracks > 0) {
-        const unsigned int nThreads = m_warp_size * 2;
+        const unsigned int nThreads =
+            m_cfg.threads_per_block ? m_cfg.threads_per_block : m_warp_size * 2;
         const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
 
         vecmem::data::vector_buffer<device::sort_key> keys_buffer(n_tracks,


### PR DESCRIPTION
## Summary
- allow custom `threads_per_block` via `fitting_config`
- use the value in CUDA fitting kernel

## Testing
- `pre-commit run --files core/include/traccc/fitting/fitting_config.hpp device/cuda/src/fitting/fitting_algorithm.cu`
- `pytest -q`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68407ab6b8c0832081074824046e39cc