### PR TITLE
Fix WMMA shared memory usage

### DIFF
--- a/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
+++ b/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
@@ -22,9 +22,15 @@ __device__ inline detray::dmatrix<algebra_t, M, N> wmma_multiply(
     const detray::dmatrix<algebra_t, M, K>& A,
     const detray::dmatrix<algebra_t, K, N>& B) {
     constexpr int TILE = 16;
-    half Ah[TILE * TILE] = {0};
-    half Bh[TILE * TILE] = {0};
-    float Ch[TILE * TILE] = {0.0f};
+    __shared__ half Ah[TILE * TILE];
+    __shared__ half Bh[TILE * TILE];
+    __shared__ float Ch[TILE * TILE];
+
+    for (int idx = 0; idx < TILE * TILE; ++idx) {
+        Ah[idx] = 0;
+        Bh[idx] = 0;
+        Ch[idx] = 0.0f;
+    }
 
     for (int i = 0; i < M; ++i) {
         for (int j = 0; j < K; ++j) {


### PR DESCRIPTION
## Summary
- address wmma warning by using shared memory in `wmma_multiply`

## Testing
- `cmake --preset cuda-fp32 -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_684085b053848320956397fa4e2d7838