### PR TITLE
Fix WMMA hang by removing shared memory

### DIFF
--- a/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
+++ b/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
@@ -23,9 +23,9 @@ __device__ inline detray::dmatrix<algebra_t, M, N> wmma_multiply(
     const detray::dmatrix<algebra_t, K, N>& B) {
     constexpr int TILE = 16;
 
-    __shared__ __align__(16) half Ah[TILE * TILE];
-    __shared__ __align__(16) half Bh[TILE * TILE];
-    __shared__ __align__(16) float Ch[TILE * TILE];
+    __align__(16) half Ah[TILE * TILE];
+    __align__(16) half Bh[TILE * TILE];
+    __align__(16) float Ch[TILE * TILE];
 
 
     for (int idx = 0; idx < TILE * TILE; ++idx) {


### PR DESCRIPTION
## Summary
- allocate WMMA tile arrays in local memory instead of shared memory

## Testing
- `cmake --preset cuda-fp32 -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68408bb5bf6c8320af3581f3b7d0fc3f