### PR TITLE
Fix WMMA warning by using fragment initialization

### DIFF
--- a/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
+++ b/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
@@ -23,46 +23,38 @@ __device__ inline detray::dmatrix<algebra_t, M, N> wmma_multiply(
     const detray::dmatrix<algebra_t, K, N>& B) {
     constexpr int TILE = 16;
 
-    __shared__ __align__(16) half Ah[TILE * TILE];
-    __shared__ __align__(16) half Bh[TILE * TILE];
-    __shared__ __align__(16) float Ch[TILE * TILE];
-
-
-    for (int idx = 0; idx < TILE * TILE; ++idx) {
-        Ah[idx] = 0;
-        Bh[idx] = 0;
-        Ch[idx] = 0.0f;
-    }
-
-    for (int i = 0; i < M; ++i) {
-        for (int j = 0; j < K; ++j) {
-            Ah[i * TILE + j] = __float2half(getter::element(A, i, j));
-        }
-    }
-    for (int i = 0; i < K; ++i) {
-        for (int j = 0; j < N; ++j) {
-            Bh[i * TILE + j] = __float2half(getter::element(B, i, j));
-        }
-    }
-
     wmma::fragment<wmma::matrix_a, TILE, TILE, TILE, half, wmma::row_major>
         a_frag;
     wmma::fragment<wmma::matrix_b, TILE, TILE, TILE, half, wmma::row_major>
         b_frag;
     wmma::fragment<wmma::accumulator, TILE, TILE, TILE, float> c_frag;
 
-    wmma::load_matrix_sync(a_frag, Ah, TILE);
-    wmma::load_matrix_sync(b_frag, Bh, TILE);
+    // Fill the fragments with zeros
+    wmma::fill_fragment(a_frag, static_cast<half>(0));
+    wmma::fill_fragment(b_frag, static_cast<half>(0));
     wmma::fill_fragment(c_frag, 0.0f);
+
+    // Copy input matrices into the fragments
+    for (int i = 0; i < M; ++i) {
+        for (int j = 0; j < K; ++j) {
+            a_frag.x[i * TILE + j] =
+                __float2half(getter::element(A, i, j));
+        }
+    }
+    for (int i = 0; i < K; ++i) {
+        for (int j = 0; j < N; ++j) {
+            b_frag.x[i * TILE + j] =
+                __float2half(getter::element(B, i, j));
+        }
+    }
+
+    // Perform the matrix multiplication
     wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);
-    wmma::store_matrix_sync(Ch, c_frag, TILE, wmma::mem_row_major);
 
     detray::dmatrix<algebra_t, M, N> C;
     for (int i = 0; i < M; ++i) {
         for (int j = 0; j < N; ++j) {
-
-            getter::element(C, i, j) = Ch[i * TILE + j];
-
+            getter::element(C, i, j) = c_frag.x[i * TILE + j];
         }
     }
     return C;


### PR DESCRIPTION
## Summary
- avoid WMMA local memory accesses by filling fragments directly

## Testing
- `cmake --preset cuda-fp32 -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68408bb5bf6c8320af3581f3b7d0fc3f