### PR TITLE
Fix WMMA hang by removing shared memory

### DIFF
--- a/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
+++ b/device/cuda/include/traccc/cuda/utils/wmma_matrix_multiply.hpp
@@ -22,11 +22,9 @@ __device__ inline detray::dmatrix<algebra_t, M, N> wmma_multiply(
     const detray::dmatrix<algebra_t, M, K>& A,
     const detray::dmatrix<algebra_t, K, N>& B) {
     constexpr int TILE = 16;
-
-    __shared__ __align__(16) half Ah[TILE * TILE];
-    __shared__ __align__(16) half Bh[TILE * TILE];
-    __shared__ __align__(16) float Ch[TILE * TILE];
-
+    alignas(16) half Ah[TILE * TILE];
+    alignas(16) half Bh[TILE * TILE];
+    alignas(16) float Ch[TILE * TILE];
 
     for (int idx = 0; idx < TILE * TILE; ++idx) {
         Ah[idx] = 0;


### PR DESCRIPTION
## Summary
- use per-thread buffers for WMMA multiply instead of shared memory to avoid conflicts

## Testing
- `cmake --preset cuda-fp32 -S . -B build -DCUDAToolkit_ROOT=/usr/lib/nvidia-cuda-toolkit` (succeeds)
- `cmake --build build -j2` *(interrupted due to long build time)*

------
https://chatgpt.com/codex/tasks/task_e_68408bb5bf6c8320af3581f3b7d0fc3f