### PR TITLE
Fix compile errors due to device container

### DIFF
--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -17,7 +17,7 @@
 namespace traccc::device {
 
 template <typename propagator_t, typename bfield_t>
-TRACCC_HOST_DEVICE TRACCC_FORCE_INLINE void propagate_to_next_surface(
+TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     const global_index_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload) {
 

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -12,7 +12,7 @@
 namespace traccc::device {
 
 template <typename fitter_t>
-TRACCC_HOST_DEVICE TRACCC_FORCE_INLINE void fit(
+TRACCC_HOST_DEVICE inline void fit(
     const global_index_t globalIndex, const typename fitter_t::config_type cfg,
     const fit_payload<fitter_t>& payload) {
 
@@ -42,7 +42,6 @@ TRACCC_HOST_DEVICE TRACCC_FORCE_INLINE void fit(
 
     // Track states per track
     auto track_states_per_track = track_states.at(param_id).items;
-    track_states_per_track.reserve(track_candidates_per_track.size());
     for (const auto& cand : track_candidates_per_track) {
         track_states_per_track.emplace_back(cand);
     }


### PR DESCRIPTION
## Summary
- remove reserve usage in device fit implementation
- adjust inline attribute usage in device code

## Testing
- `cmake --preset host-fp32 -S . -B build` *(fails: Could not find a package configuration file provided by "TBB")*

------
https://chatgpt.com/codex/tasks/task_e_684112ed3bd48320b1d8b3483531df2e