### PR TITLE
Use Gauss-Jordan inverse for gain matrix

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -12,6 +12,7 @@
 #include "traccc/definitions/track_parametrization.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/status_codes.hpp"
+#include "traccc/utils/gauss_jordan_inverse.hpp"
 
 // Detray inlcude(s)
 #include <detray/geometry/shapes/line.hpp>
@@ -110,7 +111,7 @@ struct gain_matrix_updater {
 
         // Kalman gain matrix
         const matrix_type<6, D> K =
-            predicted_cov * matrix::transpose(H) * matrix::inverse(M);
+            predicted_cov * matrix::transpose(H) * gauss_jordan_inverse(M);
 
         // Calculate the filtered track parameters
         const matrix_type<6, 1> filtered_vec =
@@ -123,7 +124,7 @@ struct gain_matrix_updater {
         // Calculate the chi square
         const matrix_type<D, D> R = (I_m - H * K) * V;
         const matrix_type<1, 1> chi2 =
-            matrix::transpose(residual) * matrix::inverse(R) * residual;
+            matrix::transpose(residual) * gauss_jordan_inverse(R) * residual;
 
         // Return false if track is parallel to z-axis or phi is not finite
         const scalar theta = bound_params.theta();

--- a/core/include/traccc/utils/gauss_jordan_inverse.hpp
+++ b/core/include/traccc/utils/gauss_jordan_inverse.hpp
@@ -1,0 +1,70 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "traccc/definitions/qualifiers.hpp"
+#include <cmath>
+#include <tuple>
+#include "traccc/definitions/primitives.hpp"
+
+namespace traccc {
+
+/// Gauss-Jordan matrix inversion inspired by
+/// "A fast parallel Gauss Jordan algorithm for matrix inversion using CUDA"
+/// by Sharma et al., Computers & Structures 2013.
+template <typename matrix_t>
+TRACCC_HOST_DEVICE inline matrix_t gauss_jordan_inverse(matrix_t mat) {
+    using size_type = std::size_t;
+    // Determine matrix dimension either via a static member or tuple_size
+    constexpr size_type N = [] {
+        if constexpr (requires { matrix_t::RowsAtCompileTime; }) {
+            return static_cast<size_type>(matrix_t::RowsAtCompileTime);
+        } else {
+            return static_cast<size_type>(std::tuple_size<matrix_t>::value);
+        }
+    }();
+    matrix_t inv = matrix::identity<matrix_t>();
+    for (size_type i = 0; i < N; ++i) {
+        size_type pivot_row = i;
+        auto pivot = getter::element(mat, i, i);
+        for (size_type r = i + 1; r < N; ++r) {
+            auto val = getter::element(mat, r, i);
+            if (std::abs(val) > std::abs(pivot)) {
+                pivot = val;
+                pivot_row = r;
+            }
+        }
+        if (pivot_row != i) {
+            for (size_type c = 0; c < N; ++c) {
+                auto tmp = getter::element(mat, i, c);
+                getter::element(mat, i, c) = getter::element(mat, pivot_row, c);
+                getter::element(mat, pivot_row, c) = tmp;
+                tmp = getter::element(inv, i, c);
+                getter::element(inv, i, c) = getter::element(inv, pivot_row, c);
+                getter::element(inv, pivot_row, c) = tmp;
+            }
+        }
+        auto piv_inv = 1 / getter::element(mat, i, i);
+        for (size_type c = 0; c < N; ++c) {
+            getter::element(mat, i, c) *= piv_inv;
+            getter::element(inv, i, c) *= piv_inv;
+        }
+        for (size_type r = 0; r < N; ++r) {
+            if (r == i) continue;
+            auto factor = getter::element(mat, r, i);
+            for (size_type c = 0; c < N; ++c) {
+                getter::element(mat, r, c) -= factor * getter::element(mat, i, c);
+                getter::element(inv, r, c) -= factor * getter::element(inv, i, c);
+            }
+        }
+    }
+    return inv;
+}
+
+} // namespace traccc
+


### PR DESCRIPTION
## Summary
- implement `gauss_jordan_inverse` in new header
- switch Kalman gain matrix code to use Gauss–Jordan inversion
- improve matrix inversion template to work with std::array matrices

## Testing
- `cmake --preset host-fp32` *(fails: Could not find TBB)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684139ee31a8832089dbf5bf986e450c