### PR TITLE
Loop unrolling in small matrix helpers

### DIFF
--- a/core/include/traccc/utils/subspace.hpp
+++ b/core/include/traccc/utils/subspace.hpp
@@ -43,10 +43,12 @@ struct subspace {
     /// @param indices Unique, ordered indices
     TRACCC_HOST_DEVICE
     constexpr subspace(const std::array<size_type, kSize>& indices) {
+        TRACCC_PRAGMA_UNROLL
         for (size_type i = 0u; i < kSize; ++i) {
             assert((indices[i] < kFullSize) and
                    "Axis indices must be within the full space");
         }
+        TRACCC_PRAGMA_UNROLL
         for (size_type i = 0; i < kSize; ++i) {
             m_axes[i] = static_cast<size_type>(indices[i]);
         }
@@ -77,6 +79,7 @@ struct subspace {
 
         auto proj = matrix::zero<matrix_type<D, kFullSize>>();
 
+        TRACCC_PRAGMA_UNROLL
         for (size_type i = 0u; i < D; ++i) {
             getter::element(proj, i, m_axes[i]) = 1;
         }
@@ -92,6 +95,7 @@ struct subspace {
 
         auto expn = matrix::zero<matrix_type<kFullSize, D>>();
 
+        TRACCC_PRAGMA_UNROLL
         for (size_type i = 0u; i < kSize; ++i) {
             getter::element(expn, m_axes[i], i) = 1;
         }

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -43,6 +43,7 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
     // Track states per track
     auto track_states_per_track = track_states.at(param_id).items;
 
+    TRACCC_PRAGMA_UNROLL
     for (auto& cand : track_candidates_per_track) {
         track_states_per_track.emplace_back(cand);
     }


### PR DESCRIPTION
## Summary
- run `traccc_data_get_files.sh` to get the data package
- unroll loops in `subspace` matrix helpers
- unroll candidate copy loop in device `fit` implementation

## Testing
- `cmake --preset host-fp32 -B build` *(fails: Could not find a package configuration file provided by "TBB")*

------
https://chatgpt.com/codex/tasks/task_e_68414a20db78832095c410d5a5da1ca9