### PR TITLE
Optimize fit and propagation

### DIFF
--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -30,24 +30,30 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
     const unsigned int param_id = param_ids.at(globalIndex);
 
+    // Parameters liveness
+    vecmem::device_vector<unsigned int> params_liveness(
+        payload.params_liveness_view);
+    if (params_liveness.at(param_id) == 0u) {
+        return;
+    }
+
     // Number of tracks per seed
     vecmem::device_vector<unsigned int> n_tracks_per_seed(
         payload.n_tracks_per_seed_view);
 
     // Links
     vecmem::device_vector<const candidate_link> links(payload.links_view);
+    const auto links_idx = payload.prev_links_idx + param_id;
+    const candidate_link link = links.at(links_idx);
 
     // Seed id
-    unsigned int orig_param_id =
-        links.at(payload.prev_links_idx + param_id).seed_idx;
+    unsigned int orig_param_id = link.seed_idx;
 
     // Count the number of tracks per seed
     vecmem::device_atomic_ref<unsigned int> num_tracks_per_seed(
         n_tracks_per_seed.at(orig_param_id));
 
     const unsigned int s_pos = num_tracks_per_seed.fetch_add(1);
-    vecmem::device_vector<unsigned int> params_liveness(
-        payload.params_liveness_view);
 
     if (s_pos >= cfg.max_num_branches_per_seed) {
         params_liveness[param_id] = 0u;
@@ -57,10 +63,9 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     // tips
     vecmem::device_vector<unsigned int> tips(payload.tips_view);
 
-    if (links.at(payload.prev_links_idx + param_id).n_skipped >
-        cfg.max_num_skipping_per_cand) {
+    if (link.n_skipped > cfg.max_num_skipping_per_cand) {
         params_liveness[param_id] = 0u;
-        tips.push_back(payload.prev_links_idx + param_id);
+        tips.push_back(links_idx);
         return;
     }
 
@@ -111,7 +116,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
         params[param_id] = propagation._stepping.bound_params();
 
         if (payload.step == cfg.max_track_candidates_per_track - 1) {
-            tips.push_back(payload.prev_links_idx + param_id);
+            tips.push_back(links_idx);
             params_liveness[param_id] = 0u;
         } else {
             params_liveness[param_id] = 1u;
@@ -120,7 +125,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
         params_liveness[param_id] = 0u;
 
         if (payload.step >= cfg.min_track_candidates_per_track - 1) {
-            tips.push_back(payload.prev_links_idx + param_id);
+            tips.push_back(links_idx);
         }
     }
 }

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -33,17 +33,19 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
 
     const unsigned int param_id = param_ids.at(globalIndex);
 
+    const auto& track_candidate = track_candidates.at(param_id);
+
     // Track candidates per track
-    const auto& track_candidates_per_track =
-        track_candidates.at(param_id).items;
+    const auto& track_candidates_per_track = track_candidate.items;
 
     // Seed parameter
-    const auto& seed_param = track_candidates.at(param_id).header.seed_params;
+    const auto& seed_param = track_candidate.header.seed_params;
 
     // Track states per track
     auto track_states_per_track = track_states.at(param_id).items;
+    track_states_per_track.reserve(track_candidates_per_track.size());
 
-    for (auto& cand : track_candidates_per_track) {
+    for (const auto& cand : track_candidates_per_track) {
         track_states_per_track.emplace_back(cand);
     }
 


### PR DESCRIPTION
## Summary
- improve caching in device `fit` to avoid multiple lookups and reserve memory
- streamline `propagate_to_next_surface` early checks and reuse link information

## Testing
- `cmake -S . -B build -DTRACCC_BUILD_TESTING=OFF` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_684271b544f883208f6495209d6abff8