### PR TITLE
Improve device computations

### DIFF
--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -37,14 +37,23 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
         return;
     }
 
-    // Number of tracks per seed
-    vecmem::device_vector<unsigned int> n_tracks_per_seed(
-        payload.n_tracks_per_seed_view);
-
     // Links
     vecmem::device_vector<const candidate_link> links(payload.links_view);
     const auto links_idx = payload.prev_links_idx + param_id;
     const candidate_link link = links.at(links_idx);
+
+    // tips
+    vecmem::device_vector<unsigned int> tips(payload.tips_view);
+
+    if (link.n_skipped > cfg.max_num_skipping_per_cand) {
+        params_liveness[param_id] = 0u;
+        tips.push_back(links_idx);
+        return;
+    }
+
+    // Number of tracks per seed
+    vecmem::device_vector<unsigned int> n_tracks_per_seed(
+        payload.n_tracks_per_seed_view);
 
     // Seed id
     unsigned int orig_param_id = link.seed_idx;
@@ -57,15 +66,6 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
     if (s_pos >= cfg.max_num_branches_per_seed) {
         params_liveness[param_id] = 0u;
-        return;
-    }
-
-    // tips
-    vecmem::device_vector<unsigned int> tips(payload.tips_view);
-
-    if (link.n_skipped > cfg.max_num_skipping_per_cand) {
-        params_liveness[param_id] = 0u;
-        tips.push_back(links_idx);
         return;
     }
 

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -43,10 +43,13 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
 
     // Track states per track
     auto track_states_per_track = track_states.at(param_id).items;
-    track_states_per_track.reserve(track_candidates_per_track.size());
+    const auto nTrackCand = track_candidates_per_track.size();
+    track_states_per_track.resize(nTrackCand);
 
-    for (const auto& cand : track_candidates_per_track) {
-        track_states_per_track.emplace_back(cand);
+    using track_state_t = typename decltype(track_states_per_track)::value_type;
+    for (unsigned int i = 0; i < nTrackCand; ++i) {
+        track_states_per_track[i] =
+            track_state_t(track_candidates_per_track.at(i));
     }
 
     typename fitter_t::state fitter_state(


### PR DESCRIPTION
## Summary
- resize output storage before filling track state vector
- skip atomic updates when candidate has too many skipped hits
- fix assignment to track-state vector when pre-allocating

## Testing
- `pre-commit run --files device/common/include/traccc/fitting/device/impl/fit.ipp device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp`

------
https://chatgpt.com/codex/tasks/task_e_6842b9b6f19c83208c63aa2c9c601fa8