### PR TITLE
Fix CUDA liveness update

### DIFF
--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -33,7 +33,10 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     vecmem::device_vector<unsigned int> params_liveness(
         payload.params_liveness_view);
 
-    if (params_liveness.at(param_id) == 0u) {
+    unsigned int& param_live_ref = params_liveness.at(param_id);
+    unsigned int param_live = param_live_ref;
+
+    if (param_live == 0u) {
         return;
     }
 
@@ -56,7 +59,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     const unsigned int s_pos = num_tracks_per_seed.fetch_add(1);
 
     if (s_pos >= cfg.max_num_branches_per_seed) {
-        params_liveness[param_id] = 0u;
+        param_live_ref = 0u;
         return;
     }
 
@@ -64,7 +67,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     vecmem::device_vector<unsigned int> tips(payload.tips_view);
 
     if (link.n_skipped > cfg.max_num_skipping_per_cand) {
-        params_liveness[param_id] = 0u;
+        param_live_ref = 0u;
         tips.push_back(link_idx);
         return;
     }
@@ -74,10 +77,6 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
     // Parameters
     bound_track_parameters_collection_types::device params(payload.params_view);
-
-    if (params_liveness.at(param_id) == 0u) {
-        return;
-    }
 
     // Input bound track parameter
     const bound_track_parameters<> in_par = params.at(param_id);
@@ -117,12 +116,12 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
         if (payload.step == cfg.max_track_candidates_per_track - 1) {
             tips.push_back(link_idx);
-            params_liveness[param_id] = 0u;
+            param_live_ref = 0u;
         } else {
-            params_liveness[param_id] = 1u;
+            param_live_ref = 1u;
         }
     } else {
-        params_liveness[param_id] = 0u;
+        param_live_ref = 0u;
 
         if (payload.step >= cfg.min_track_candidates_per_track - 1) {
             tips.push_back(link_idx);

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -16,8 +16,6 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
                                    const typename fitter_t::config_type cfg,
                                    const fit_payload<fitter_t>& payload) {
 
-    typename fitter_t::detector_type det(payload.det_data);
-
     track_candidate_container_types::const_device track_candidates(
         payload.track_candidates_view);
 
@@ -25,11 +23,13 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
 
     track_state_container_types::device track_states(payload.track_states_view);
 
-    fitter_t fitter(det, payload.field_data, cfg);
-
     if (globalIndex >= track_states.size()) {
         return;
     }
+
+    typename fitter_t::detector_type det(payload.det_data);
+
+    fitter_t fitter(det, payload.field_data, cfg);
 
     const unsigned int param_id = param_ids.at(globalIndex);
 


### PR DESCRIPTION
## Summary
- use a reference for liveness flag instead of non-existent `ptr()` method
- keep early exit optimization in `fit`

## Testing
- `pre-commit run --files device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp device/common/include/traccc/fitting/device/impl/fit.ipp`

------
https://chatgpt.com/codex/tasks/task_e_68433507b2f4832087201f9d35582114