### PR TITLE
Optimize device algorithms

### DIFF
--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -19,7 +19,7 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
     track_candidate_container_types::const_device track_candidates(
         payload.track_candidates_view);
 
-    vecmem::device_vector<const unsigned int> param_ids(payload.param_ids_view);
+    const unsigned int* param_ids = payload.param_ids_view.ptr();
 
     track_state_container_types::device track_states(payload.track_states_view);
 
@@ -31,7 +31,7 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
 
     fitter_t fitter(det, payload.field_data, cfg);
 
-    const unsigned int param_id = param_ids.at(globalIndex);
+    const unsigned int param_id = *(param_ids + globalIndex);
 
     // Track candidates and states for this track
     const auto track_candidate_track = track_candidates.at(param_id);
@@ -41,7 +41,7 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
     const auto& seed_param = track_candidate_track.header.seed_params;
 
     auto track_states_track = track_states.at(param_id);
-    auto track_states_per_track = track_states_track.items;
+    auto& track_states_per_track = track_states_track.items;
 
     for (auto& cand : track_candidates_per_track) {
         track_states_per_track.emplace_back(cand);


### PR DESCRIPTION
## Summary
- reduce object constructions and use pointer access in `fit`
- check skipped measurements before atomic operations in `propagate_to_next_surface`
- avoid vector object creation for several views

## Testing
- `pre-commit run --files device/common/include/traccc/fitting/device/impl/fit.ipp device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp`

------
https://chatgpt.com/codex/tasks/task_e_68433e0ad97083208936c16c18a931d9