### PR TITLE
Fix constant config definition to avoid redefinition

### DIFF
--- a/device/cuda/src/finding/kernels/kernel_config.cu
+++ b/device/cuda/src/finding/kernels/kernel_config.cu
@@ -1,7 +1,7 @@
 #include "kernel_config.cuh"
 
 namespace traccc::cuda::kernels {
-__constant__ finding_config g_finding_cfg;
+__device__ finding_config g_finding_cfg;
 
 void load_finding_config(const finding_config& cfg) {
     cudaMemcpyToSymbol(g_finding_cfg, &cfg, sizeof(finding_config));

--- a/device/cuda/src/finding/kernels/kernel_config.cuh
+++ b/device/cuda/src/finding/kernels/kernel_config.cuh
@@ -3,6 +3,6 @@
 #include <cuda_runtime.h>
 
 namespace traccc::cuda::kernels {
-extern __constant__ finding_config g_finding_cfg;
+extern __device__ finding_config g_finding_cfg;
 void load_finding_config(const finding_config& cfg);
 }


### PR DESCRIPTION
## Summary
- store CUDA finding config in `__device__` global memory instead of constant memory

## Testing
- `cmake --preset cuda-fp32 -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6843e241c2108320b798638070cedba5