### PR TITLE
Fix CUDA config variable definition

### DIFF
--- a/device/cuda/src/finding/kernels/kernel_config.cu
+++ b/device/cuda/src/finding/kernels/kernel_config.cu
@@ -1,7 +1,7 @@
+#define TRACCC_DEFINE_FINDING_CONFIG
 #include "kernel_config.cuh"
 
 namespace traccc::cuda::kernels {
-__constant__ finding_config g_finding_cfg;
 
 void load_finding_config(const finding_config& cfg) {
     cudaMemcpyToSymbol(g_finding_cfg, &cfg, sizeof(finding_config));

--- a/device/cuda/src/finding/kernels/kernel_config.cuh
+++ b/device/cuda/src/finding/kernels/kernel_config.cuh
@@ -1,8 +1,16 @@
 #pragma once
-#include "traccc/finding/finding_config.hpp"
 #include <cuda_runtime.h>
 
+#include "traccc/finding/finding_config.hpp"
+
 namespace traccc::cuda::kernels {
-extern __constant__ finding_config g_finding_cfg;
+
+#ifdef TRACCC_DEFINE_FINDING_CONFIG
+__device__ __constant__ finding_config g_finding_cfg;
+#else
+extern __device__ __constant__ finding_config g_finding_cfg;
+#endif
+
 void load_finding_config(const finding_config& cfg);
-}
+
+}  // namespace traccc::cuda::kernels


### PR DESCRIPTION
## Summary
- ensure CUDA finding config variable uses explicit `__device__` qualifier
- allow other kernels to reference the variable without redefinition errors

## Testing
- `pre-commit run --files device/cuda/src/finding/kernels/kernel_config.cuh device/cuda/src/finding/kernels/kernel_config.cu`
- `cmake --preset cuda-fp32 -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6843e241c2108320b798638070cedba5