### PR TITLE
Use constant memory for CUDA seeding config

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -44,6 +44,8 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/seeding/seeding_algorithm.cpp"
   "include/traccc/cuda/seeding/spacepoint_formation_algorithm.hpp"
   "src/seeding/spacepoint_formation_algorithm.cu"
+  "src/seeding/kernel_config.cu"
+  "src/seeding/kernel_config.cuh"
   # Clusterization
   "include/traccc/cuda/clusterization/clusterization_algorithm.hpp"
   "src/clusterization/clusterization_algorithm.cu"

--- a/device/cuda/src/seeding/kernel_config.cu
+++ b/device/cuda/src/seeding/kernel_config.cu
@@ -1,0 +1,14 @@
+#define TRACCC_DEFINE_SEEDING_CONFIG
+#include "kernel_config.cuh"
+
+namespace traccc::cuda::kernels {
+
+void load_seeding_config(const seedfinder_config& finder_cfg,
+                         const seedfilter_config& filter_cfg) {
+    cudaMemcpyToSymbol(g_seedfinder_cfg_bytes, &finder_cfg,
+                       sizeof(seedfinder_config));
+    cudaMemcpyToSymbol(g_seedfilter_cfg, &filter_cfg,
+                       sizeof(seedfilter_config));
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/seeding/kernel_config.cuh
+++ b/device/cuda/src/seeding/kernel_config.cuh
@@ -1,0 +1,26 @@
+#pragma once
+#include <cuda_runtime.h>
+
+#include "traccc/seeding/detail/seeding_config.hpp"
+
+namespace traccc::cuda::kernels {
+
+#ifdef TRACCC_DEFINE_SEEDING_CONFIG
+__constant__ alignas(seedfinder_config) unsigned char g_seedfinder_cfg_bytes
+    [sizeof(seedfinder_config)];
+__constant__ seedfilter_config g_seedfilter_cfg;
+#else
+extern __constant__ alignas(
+    seedfinder_config) unsigned char g_seedfinder_cfg_bytes
+    [sizeof(seedfinder_config)];
+extern __constant__ seedfilter_config g_seedfilter_cfg;
+#endif
+
+TRACCC_DEVICE inline const seedfinder_config& get_seedfinder_cfg() {
+    return *reinterpret_cast<const seedfinder_config*>(g_seedfinder_cfg_bytes);
+}
+
+void load_seeding_config(const seedfinder_config& finder_cfg,
+                         const seedfilter_config& filter_cfg);
+
+}  // namespace traccc::cuda::kernels


### PR DESCRIPTION
## Summary
- download data with `traccc_data_get_files.sh`
- store `seedfinder_config` and `seedfilter_config` in CUDA constant memory
- load seeding config before launching kernels
- fix device constant initialization by storing raw bytes and providing accessor

## Testing
- `pre-commit run --files device/cuda/src/seeding/kernel_config.cu device/cuda/src/seeding/kernel_config.cuh device/cuda/src/seeding/seed_finding.cu device/cuda/CMakeLists.txt`

------
https://chatgpt.com/codex/tasks/task_e_6843fa117c78832082af15f095e5a8a7