### PR TITLE
Fix CUDA payload initialization

### DIFF
--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -14,6 +14,7 @@
 #include "traccc/definitions/qualifiers.hpp"
 #include "traccc/edm/track_candidate.hpp"
 #include "traccc/edm/track_state.hpp"
+#include "traccc/fitting/device/soa_types.hpp"
 
 namespace traccc::device {
 
@@ -39,6 +40,12 @@ struct fit_payload {
      * @brief View object to the input track parameters
      */
     vecmem::data::vector_view<const unsigned int> param_ids_view;
+
+    /// Optional SoA views of track candidates
+    track_candidate_soa candidate_soa{};
+
+    /// Optional SoA views of track states
+    track_state_soa state_soa{};
 
     /**
      * @brief View object to the output track states

--- a/device/common/include/traccc/fitting/device/soa_types.hpp
+++ b/device/common/include/traccc/fitting/device/soa_types.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/containers/device_vector.hpp>
+
+namespace traccc::device {
+
+/// Simple struct-of-arrays view used for the CUDA fitting kernels.
+struct track_candidate_soa {
+    float4* __restrict__ loc_var = nullptr;  ///< local0, local1, var0, var1
+    unsigned int* __restrict__ offsets =
+        nullptr;  ///< prefix sum offsets per track
+};
+
+struct track_state_soa {
+    float4* __restrict__ loc_var = nullptr;  ///< local0, local1, var0, var1
+    unsigned int* __restrict__ offsets =
+        nullptr;  ///< prefix sum offsets per track
+};
+
+}  // namespace traccc::device

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -12,6 +12,8 @@
 #include "traccc/cuda/fitting/fitting_algorithm.hpp"
 #include "traccc/fitting/device/fill_sort_keys.hpp"
 #include "traccc/fitting/device/fit.hpp"
+#include <vecmem/containers/data/vector_view.hpp>
+#include "traccc/fitting/device/soa_types.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/utils/detector_type_utils.hpp"
@@ -41,6 +43,26 @@ __global__ void fit(const typename fitter_t::config_type cfg,
                     const device::fit_payload<fitter_t> payload) {
 
     device::fit<fitter_t>(details::global_index1(), cfg, payload);
+}
+
+__global__ void fill_candidate_soa(
+    track_candidate_container_types::const_view track_candidates_view,
+    vecmem::data::vector_view<float4> lv,
+    vecmem::data::vector_view<const unsigned int> offsets) {
+    const track_candidate_container_types::const_device track_candidates(
+        track_candidates_view);
+    vecmem::device_vector<float4> lv_dev(lv);
+    vecmem::device_vector<const unsigned int> off_dev(offsets);
+
+    unsigned int idx = details::global_index1();
+    if (idx >= track_candidates.size()) return;
+    auto cands = track_candidates.at(idx).items;
+    unsigned int off = off_dev[idx];
+    for (unsigned int i = 0; i < cands.size(); ++i) {
+        const auto& c = cands[i];
+        lv_dev[off + i] =
+            make_float4(c.local[0], c.local[1], c.variance[0], c.variance[1]);
+    }
 }
 
 }  // namespace kernels
@@ -121,15 +143,44 @@ track_state_container_types::buffer fitting_algorithm<fitter_t>::operator()(
                             keys_device.begin(), keys_device.end(),
                             param_ids_device.begin());
 
+        // Prepare SoA layout for measurements
+        std::vector<unsigned int> offsets(n_tracks + 1, 0);
+        for (std::size_t i = 0; i < candidate_sizes.size(); ++i) {
+            offsets[i + 1] = offsets[i] + candidate_sizes[i];
+        }
+        vecmem::data::vector_buffer<float4> cand_lv_buffer(offsets.back(),
+                                                           m_mr.main);
+        vecmem::data::vector_buffer<unsigned int> offset_buffer(offsets.size(),
+                                                                m_mr.main);
+        m_copy.setup(cand_lv_buffer)->ignore();
+        m_copy.setup(offset_buffer)->ignore();
+        vecmem::data::vector_view<const unsigned int> offsets_view(
+            offsets.size(), offsets.data());
+        m_copy(offsets_view, offset_buffer,
+                vecmem::copy::type::host_to_device)
+            ->ignore();
+
+        // Convert device buffers into views that can be used by the kernel
+        auto cand_lv_view = vecmem::get_data(cand_lv_buffer);
+        auto offset_view = vecmem::get_data(offset_buffer);
+
+        kernels::fill_candidate_soa<<<nBlocks, nThreads, 0, stream>>>(
+            track_candidates_view, cand_lv_view, offset_view);
+        TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+
         // Run the track fitting
-        kernels::fit<fitter_t><<<nBlocks, nThreads, 0, stream>>>(
-            m_cfg, device::fit_payload<fitter_t>{
-                       .det_data = det_view,
-                       .field_data = field_view,
-                       .track_candidates_view = track_candidates_view,
-                       .param_ids_view = param_ids_buffer,
-                       .track_states_view = track_states_buffer,
-                       .barcodes_view = seqs_buffer});
+        const device::fit_payload<fitter_t> payload{
+            det_view,
+            field_view,
+            track_candidates_view,
+            param_ids_buffer,
+            {cand_lv_view.ptr(), offset_view.ptr()},
+            {},
+            track_states_buffer,
+            seqs_buffer};
+
+        kernels::fit<fitter_t><<<nBlocks, nThreads, 0, stream>>>(m_cfg,
+                                                                payload);
         TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
     }
 


### PR DESCRIPTION
## Summary
- add SoA struct definitions for candidate and state data
- allocate SoA buffers and pass pointers through payload
- construct CUDA fit payload via aggregate initialization
- fix vector_view constructor call ordering

## Testing
- `./data/traccc_data_get_files.sh` *(failed: download incomplete)*
- `pre-commit run --files device/cuda/src/fitting/fitting_algorithm.cu device/common/include/traccc/fitting/device/soa_types.hpp` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844291d7ac883209be81cd53408e5a4