### PR TITLE
Add sync points to reduce register pressure

### DIFF
--- a/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -9,8 +9,8 @@
 
 // Local include(s).
 #include "../../../utils/global_index.hpp"
-#include "../propagate_to_next_surface.cuh"
 #include "../kernel_config.cuh"
+#include "../propagate_to_next_surface.cuh"
 
 // Project include(s).
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
@@ -23,6 +23,11 @@ __global__ void propagate_to_next_surface(
 
     device::propagate_to_next_surface<propagator_t, bfield_t>(
         details::global_index1(), g_finding_cfg, payload);
+
+#ifdef __CUDA_ARCH__
+    // Synchronize threads to reduce register pressure
+    __syncthreads();
+#endif
 }
 
 }  // namespace traccc::cuda::kernels

--- a/device/cuda/src/fitting/fitting_algorithm.cu
+++ b/device/cuda/src/fitting/fitting_algorithm.cu
@@ -41,6 +41,11 @@ __global__ void fit(const typename fitter_t::config_type cfg,
                     const device::fit_payload<fitter_t> payload) {
 
     device::fit<fitter_t>(details::global_index1(), cfg, payload);
+
+#ifdef __CUDA_ARCH__
+    // Block-level synchronization to release registers early
+    __syncthreads();
+#endif
 }
 
 }  // namespace kernels


### PR DESCRIPTION
## Summary
- insert block-level `__syncthreads()` after `device::fit` call
- insert block-level `__syncthreads()` after `propagate_to_next_surface` call

## Testing
- `pre-commit run --files device/cuda/src/fitting/fitting_algorithm.cu device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh`

------
https://chatgpt.com/codex/tasks/task_e_6844f402a9c0832097a210d502f6e7a4