### PR TITLE
Use shared memory for kernel parameter indices

### DIFF
--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -30,6 +30,15 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
 
     const unsigned int param_id = param_ids.at(globalIndex);
 
+    propagate_to_next_surface(globalIndex, cfg, payload, param_id);
+}
+
+template <typename propagator_t, typename bfield_t>
+TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
+    const global_index_t globalIndex, const finding_config& cfg,
+    const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload,
+    unsigned int param_id) {
+
     // Number of tracks per seed
     vecmem::device_vector<unsigned int> n_tracks_per_seed(
         payload.n_tracks_per_seed_view);

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -98,6 +98,12 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     global_index_t globalIndex, const finding_config& cfg,
     const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload);
 
+template <typename propagator_t, typename bfield_t>
+TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
+    global_index_t globalIndex, const finding_config& cfg,
+    const propagate_to_next_surface_payload<propagator_t, bfield_t>& payload,
+    unsigned int param_id);
+
 }  // namespace traccc::device
 
 // Include the implementation.

--- a/device/common/include/traccc/fitting/device/fit.hpp
+++ b/device/common/include/traccc/fitting/device/fit.hpp
@@ -64,6 +64,12 @@ TRACCC_HOST_DEVICE inline void fit(global_index_t globalIndex,
                                    const typename fitter_t::config_type cfg,
                                    const fit_payload<fitter_t>&);
 
+template <typename fitter_t>
+TRACCC_HOST_DEVICE inline void fit(global_index_t globalIndex,
+                                   const typename fitter_t::config_type cfg,
+                                   const fit_payload<fitter_t>&,
+                                   unsigned int param_id);
+
 }  // namespace traccc::device
 
 // Include the implementation.

--- a/device/common/include/traccc/fitting/device/impl/fit.ipp
+++ b/device/common/include/traccc/fitting/device/impl/fit.ipp
@@ -33,6 +33,28 @@ TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
 
     const unsigned int param_id = param_ids.at(globalIndex);
 
+    fit<fitter_t>(globalIndex, cfg, payload, param_id);
+}
+
+template <typename fitter_t>
+TRACCC_HOST_DEVICE inline void fit(const global_index_t globalIndex,
+                                   const typename fitter_t::config_type cfg,
+                                   const fit_payload<fitter_t>& payload,
+                                   unsigned int param_id) {
+
+    typename fitter_t::detector_type det(payload.det_data);
+
+    track_candidate_container_types::const_device track_candidates(
+        payload.track_candidates_view);
+
+    track_state_container_types::device track_states(payload.track_states_view);
+
+    fitter_t fitter(det, payload.field_data, cfg);
+
+    if (globalIndex >= track_states.size()) {
+        return;
+    }
+
     // Track candidates per track
     const auto& track_candidates_per_track =
         track_candidates.at(param_id).items;

--- a/device/cuda/src/finding/finding_algorithm.cu
+++ b/device/cuda/src/finding/finding_algorithm.cu
@@ -349,7 +349,8 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                     (n_candidates + nThreads - 1) / nThreads;
                 kernels::propagate_to_next_surface<
                     std::decay_t<propagator_type>, std::decay_t<bfield_type>>
-                    <<<nBlocks, nThreads, 0, stream>>>(
+                    <<<nBlocks, nThreads,
+                       nThreads * sizeof(unsigned int), stream>>>(
                         device::propagate_to_next_surface_payload<
                             std::decay_t<propagator_type>,
                             std::decay_t<bfield_type>>{


### PR DESCRIPTION
## Summary
- preload parameter ids into shared memory in CUDA kernels
- expose new device helpers taking preloaded ids
- use shared memory when launching `fit` and `propagate_to_next_surface`

## Testing
- `ctest -N`

------
https://chatgpt.com/codex/tasks/task_e_6844fecfd9a08320b4df8b666b4b5abf