### PR TITLE
Use constant memory for CUDA configs

### DIFF
--- a/device/cuda/CMakeLists.txt
+++ b/device/cuda/CMakeLists.txt
@@ -51,6 +51,8 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/clusterization/measurement_sorting_algorithm.cu"
   "src/clusterization/kernels/ccl_kernel.cu"
   "src/clusterization/kernels/ccl_kernel.cuh"
+  "src/clusterization/kernels/kernel_config.cu"
+  "src/clusterization/kernels/kernel_config.cuh"
   # Finding
   "include/traccc/cuda/finding/finding_algorithm.hpp"
   "src/finding/finding_algorithm.cu"
@@ -72,7 +74,9 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/finding/kernels/specializations/propagate_to_next_surface_default_detector.cu"
   # Fitting
   "include/traccc/cuda/fitting/fitting_algorithm.hpp"
-  "src/fitting/fitting_algorithm.cu")
+  "src/fitting/fitting_algorithm.cu"
+  "src/fitting/kernels/kernel_config.cu"
+  "src/fitting/kernels/kernel_config.cuh")
 
 if(TRACCC_ENABLE_NVTX_PROFILING)
     traccc_add_library(

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cu
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cu
@@ -12,6 +12,7 @@
 #include "../../utils/cuda_error_handling.hpp"
 #include "../../utils/thread_id.hpp"
 #include "../../utils/utils.hpp"
+#include "kernel_config.cuh"
 #include "traccc/clusterization/clustering_config.hpp"
 #include "traccc/clusterization/device/ccl_kernel_definitions.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
@@ -29,7 +30,6 @@ namespace traccc::cuda::kernels {
 
 /// CUDA kernel for running @c traccc::device::ccl_kernel
 __global__ void ccl_kernel(
-    const clustering_config cfg,
     const edm::silicon_cell_collection::const_view cells_view,
     const silicon_detector_description::const_view det_descr_view,
     measurement_collection_types::view measurements_view,
@@ -49,14 +49,15 @@ __global__ void ccl_kernel(
         vecmem::data::vector_view<device::details::index_t>::size_type;
 
     vecmem::data::vector_view<device::details::index_t> f_view{
-        static_cast<vector_size_t>(cfg.max_partition_size()), shared_v};
+        static_cast<vector_size_t>(g_clustering_cfg.max_partition_size()),
+        shared_v};
     vecmem::data::vector_view<device::details::index_t> gf_view{
-        static_cast<vector_size_t>(cfg.max_partition_size()),
-        shared_v + cfg.max_partition_size()};
+        static_cast<vector_size_t>(g_clustering_cfg.max_partition_size()),
+        shared_v + g_clustering_cfg.max_partition_size()};
     traccc::cuda::barrier barry_r;
     const details::thread_id1 thread_id;
 
-    device::ccl_kernel(cfg, thread_id, cells_view, det_descr_view,
+    device::ccl_kernel(g_clustering_cfg, thread_id, cells_view, det_descr_view,
                        partition_start, partition_end, outi, f_view, gf_view,
                        f_backup_view, gf_backup_view, adjc_backup_view,
                        adjv_backup_view, backup_mutex, barry_r,

--- a/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
+++ b/device/cuda/src/clusterization/kernels/ccl_kernel.cuh
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "kernel_config.cuh"
 #include "traccc/clusterization/clustering_config.hpp"
 #include "traccc/clusterization/device/ccl_kernel_definitions.hpp"
 #include "traccc/cuda/clusterization/clusterization_algorithm.hpp"
@@ -14,7 +15,6 @@
 namespace traccc::cuda::kernels {
 
 __global__ void ccl_kernel(
-    const clustering_config cfg,
     const edm::silicon_cell_collection::const_view cells_view,
     const silicon_detector_description::const_view det_descr_view,
     measurement_collection_types::view measurements_view,

--- a/device/cuda/src/clusterization/kernels/kernel_config.cu
+++ b/device/cuda/src/clusterization/kernels/kernel_config.cu
@@ -1,0 +1,11 @@
+#define TRACCC_DEFINE_CLUSTERING_CONFIG
+#include "kernel_config.cuh"
+
+namespace traccc::cuda::kernels {
+
+void load_clustering_config(const traccc::clustering_config& cfg) {
+    cudaMemcpyToSymbol(g_clustering_cfg, &cfg,
+                       sizeof(traccc::clustering_config));
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/clusterization/kernels/kernel_config.cuh
+++ b/device/cuda/src/clusterization/kernels/kernel_config.cuh
@@ -1,0 +1,16 @@
+#pragma once
+#include <cuda_runtime.h>
+
+#include "traccc/clusterization/clustering_config.hpp"
+
+namespace traccc::cuda::kernels {
+
+#ifdef TRACCC_DEFINE_CLUSTERING_CONFIG
+__constant__ traccc::clustering_config g_clustering_cfg;
+#else
+extern __constant__ traccc::clustering_config g_clustering_cfg;
+#endif
+
+void load_clustering_config(const traccc::clustering_config& cfg);
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/fitting/kernels/kernel_config.cu
+++ b/device/cuda/src/fitting/kernels/kernel_config.cu
@@ -1,0 +1,10 @@
+#define TRACCC_DEFINE_FITTING_CONFIG
+#include "kernel_config.cuh"
+
+namespace traccc::cuda::kernels {
+
+void load_fitting_config(const traccc::fitting_config& cfg) {
+    cudaMemcpyToSymbol(g_fitting_cfg, &cfg, sizeof(traccc::fitting_config));
+}
+
+}  // namespace traccc::cuda::kernels

--- a/device/cuda/src/fitting/kernels/kernel_config.cuh
+++ b/device/cuda/src/fitting/kernels/kernel_config.cuh
@@ -1,0 +1,16 @@
+#pragma once
+#include <cuda_runtime.h>
+
+#include "traccc/fitting/fitting_config.hpp"
+
+namespace traccc::cuda::kernels {
+
+#ifdef TRACCC_DEFINE_FITTING_CONFIG
+__constant__ traccc::fitting_config g_fitting_cfg;
+#else
+extern __constant__ traccc::fitting_config g_fitting_cfg;
+#endif
+
+void load_fitting_config(const traccc::fitting_config& cfg);
+
+}  // namespace traccc::cuda::kernels


### PR DESCRIPTION
## Summary
- download traccc data files
- speed up CUDA kernels by storing configuration in constant memory
  - add constant-memory config loaders for fitting and clusterization
  - use constant-memory configs in `fit` and `ccl_kernel`
  - expose new files to CMake

## Testing
- `pre-commit run --files device/cuda/src/fitting/fitting_algorithm.cu device/cuda/src/fitting/kernels/kernel_config.cu device/cuda/src/fitting/kernels/kernel_config.cuh device/cuda/src/clusterization/kernels/ccl_kernel.cu device/cuda/src/clusterization/kernels/ccl_kernel.cuh device/cuda/src/clusterization/clusterization_algorithm.cu device/cuda/src/clusterization/kernels/kernel_config.cu device/cuda/src/clusterization/kernels/kernel_config.cuh device/cuda/CMakeLists.txt`

------
https://chatgpt.com/codex/tasks/task_e_68451606d6e0832087fb900215074fc6