### PR TITLE
Optimize propagate kernel

### DIFF
--- a/device/alpaka/src/finding/finding_algorithm.cpp
+++ b/device/alpaka/src/finding/finding_algorithm.cpp
@@ -355,9 +355,12 @@ finding_algorithm<stepper_t, navigator_t>::operator()(
                     ::alpaka::allocBuf<PayloadType, Idx>(devHost, 1u);
                 PayloadType* payload = ::alpaka::getPtrNative(bufHost_payload);
 
+                propagator_type propagator(m_cfg.propagation);
+
                 new (payload) PayloadType{
                     .det_data = det_view,
                     .field_data = field_view,
+                    .propagator = propagator,
                     .params_view = vecmem::get_data(in_params_buffer),
                     .params_liveness_view =
                         vecmem::get_data(param_liveness_buffer),

--- a/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -81,8 +81,8 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     // Input bound track parameter
     const bound_track_parameters<> in_par = params.at(param_id);
 
-    // Create propagator
-    propagator_t propagator(cfg.propagation);
+    // Use the pre-initialised propagator to avoid per-thread construction
+    const propagator_t& propagator = payload.propagator;
 
     // Create propagator state
     typename propagator_t::state propagation(in_par, payload.field_data, det);

--- a/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -80,6 +80,9 @@ struct propagate_to_next_surface_payload {
      * input seed
      */
     vecmem::data::vector_view<unsigned int> n_tracks_per_seed_view;
+
+    /// Pre-initialised propagator object used for the propagation step
+    propagator_t propagator;
 };
 
 /// Function for propagating the kalman-updated tracks to the next surface

--- a/device/sycl/src/finding/find_tracks.hpp
+++ b/device/sycl/src/finding/find_tracks.hpp
@@ -385,6 +385,7 @@ track_candidate_container_types::buffer find_tracks(
                         kernels::propagate_to_next_surface<kernel_t>>(
                         calculate1DimNdRange(n_candidates, 64),
                         [config, det, field,
+                         propagator = propagator_type(config.propagation),
                          in_params = vecmem::get_data(in_params_buffer),
                          param_liveness =
                              vecmem::get_data(param_liveness_buffer),
@@ -401,7 +402,8 @@ track_candidate_container_types::buffer find_tracks(
                                 details::global_index(item), config,
                                 {det, field, in_params, param_liveness,
                                  param_ids, links_view, prev_links_idx, step,
-                                 n_candidates, tips, n_tracks_per_seed});
+                                 n_candidates, tips, n_tracks_per_seed,
+                                 propagator});
                         });
                 })
                 .wait_and_throw();


### PR DESCRIPTION
## Summary
- avoid per-thread construction of propagator in `propagate_to_next_surface`
- pass a pre-initialised propagator object via kernel payloads

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684536a4aac88320817a4cbbd4612de9