### PR TITLE
Fix CUDA compile failure by inlining GRU weights

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
@@ -4,7 +4,7 @@
 namespace traccc::fitting {
 template <typename algebra_t, std::size_t D>
 struct kalman_int8_gru_gain_predictor_weights {
-    static constexpr std::int8_t W0[3712] = {
+    static constexpr inline std::int8_t W0[3712] = {
         0,         -3,         3,         -5,         2,         -2,         5,         -6,         1,         -2,         4,         -4,         2,         -1,         6,         -6,
         0,         -3,         4,         -4,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         3,         0,         6,         -6,
         0,         -3,         3,         -5,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         3,         -1,         6,         -6,
@@ -239,7 +239,7 @@ struct kalman_int8_gru_gain_predictor_weights {
         1,         -2,         4,         -4,         2,         -1,         5,         -5,         2,         -2,         5,         -3,         3,         0,         6,         -6,
 
     };
-    static constexpr std::int8_t W1[2048] = {
+    static constexpr inline std::int8_t W1[2048] = {
         1,         -2,         4,         -4,         2,         -1,         6,         -6,         0,         -3,         4,         -4,         2,         -1,         5,         -5,
         1,         -2,         4,         -3,         3,         0,         6,         -6,         0,         -3,         3,         -4,         2,         -1,         5,         -5,
         1,         -2,         4,         -4,         3,         -1,         6,         -6,         1,         -2,         4,         -4,         2,         -1,         5,         -5,
@@ -370,7 +370,7 @@ struct kalman_int8_gru_gain_predictor_weights {
         2,         -2,         5,         -3,         3,         0,         6,         -6,         0,         -3,         3,         -5,         2,         -1,         5,         -5,
 
     };
-    static constexpr std::int8_t W2[384] = {
+    static constexpr inline std::int8_t W2[384] = {
         0,         -3,         3,         -5,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         2,         -1,         6,         -6,
         1,         -3,         4,         -4,         2,         -1,         5,         -5,         1,         -2,         4,         -3,         3,         0,         6,         -6,
         0,         -3,         3,         -4,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         3,         0,         6,         -6,


### PR DESCRIPTION
## Summary
- inline the GRU weight arrays so CUDA device code sees their definitions

## Testing
- `ctest -V` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b9e7d1d88320929bc5c71267042f