### PR TITLE
Fix device linkage for int8 GRU predictor weights

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
@@ -4,7 +4,7 @@
 namespace traccc::fitting {
 template <typename algebra_t, std::size_t D>
 struct kalman_int8_gru_gain_predictor_weights {
-    static constexpr inline std::int8_t W0[3712] = {
+    static constexpr TRACCC_DEVICE inline std::int8_t W0[3712] = {
         0,         -3,         3,         -5,         2,         -2,         5,         -6,         1,         -2,         4,         -4,         2,         -1,         6,         -6,
         0,         -3,         4,         -4,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         3,         0,         6,         -6,
         0,         -3,         3,         -5,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         3,         -1,         6,         -6,
@@ -239,7 +239,7 @@ struct kalman_int8_gru_gain_predictor_weights {
         1,         -2,         4,         -4,         2,         -1,         5,         -5,         2,         -2,         5,         -3,         3,         0,         6,         -6,
 
     };
-    static constexpr inline std::int8_t W1[2048] = {
+    static constexpr TRACCC_DEVICE inline std::int8_t W1[2048] = {
         1,         -2,         4,         -4,         2,         -1,         6,         -6,         0,         -3,         4,         -4,         2,         -1,         5,         -5,
         1,         -2,         4,         -3,         3,         0,         6,         -6,         0,         -3,         3,         -4,         2,         -1,         5,         -5,
         1,         -2,         4,         -4,         3,         -1,         6,         -6,         1,         -2,         4,         -4,         2,         -1,         5,         -5,
@@ -370,7 +370,7 @@ struct kalman_int8_gru_gain_predictor_weights {
         2,         -2,         5,         -3,         3,         0,         6,         -6,         0,         -3,         3,         -5,         2,         -1,         5,         -5,
 
     };
-    static constexpr inline std::int8_t W2[384] = {
+    static constexpr TRACCC_DEVICE inline std::int8_t W2[384] = {
         0,         -3,         3,         -5,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         2,         -1,         6,         -6,
         1,         -3,         4,         -4,         2,         -1,         5,         -5,         1,         -2,         4,         -3,         3,         0,         6,         -6,
         0,         -3,         3,         -4,         2,         -1,         5,         -5,         1,         -2,         4,         -4,         3,         0,         6,         -6,


### PR DESCRIPTION
## Summary
- mark int8 GRU predictor weight arrays with `TRACCC_DEVICE` so CUDA device code can access them

## Testing
- `cmake -S . -B build -DTRACCC_BUILD_CUDA=OFF -DTRACCC_BUILD_TESTING=OFF` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6847bcb0a1608320af51e992430b981e