### PR TITLE
Optimize int8 GRU predictor memory loads

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor.hpp
@@ -110,8 +110,8 @@ struct kalman_int8_gru_gain_predictor {
             const auto* Wp = reinterpret_cast<const int*>(W);
             TRACCC_PRAGMA_UNROLL
             for (size_type j = 0; j < InputStep * 4; j += 4) {
-                const accum_t w = Wp[i * InputStep + j / 4];
-                const accum_t v = *reinterpret_cast<const int*>(&x_q[j]);
+                const int w = __ldg(&Wp[i * InputStep + j / 4]);
+                const int v = *reinterpret_cast<const int*>(&x_q[j]);
                 acc = __dp4a(w, v, acc);
             }
 #else
@@ -142,8 +142,8 @@ struct kalman_int8_gru_gain_predictor {
             const auto* Wp = reinterpret_cast<const int*>(W);
             TRACCC_PRAGMA_UNROLL
             for (size_type j = 0; j < HiddenSize1; j += 4) {
-                const accum_t w = Wp[i * HiddenStep1 + j / 4];
-                const accum_t v = *reinterpret_cast<const int*>(&h0_q[j]);
+                const int w = __ldg(&Wp[i * HiddenStep1 + j / 4]);
+                const int v = *reinterpret_cast<const int*>(&h0_q[j]);
                 acc = __dp4a(w, v, acc);
             }
 #else
@@ -177,8 +177,8 @@ struct kalman_int8_gru_gain_predictor {
             const auto* Wp = reinterpret_cast<const int*>(W);
             TRACCC_PRAGMA_UNROLL
             for (size_type j = 0; j < HiddenSize2; j += 4) {
-                const accum_t w = Wp[o * HiddenStep2 + j / 4];
-                const accum_t v = *reinterpret_cast<const int*>(&h1_q[j]);
+                const int w = __ldg(&Wp[o * HiddenStep2 + j / 4]);
+                const int v = *reinterpret_cast<const int*>(&h1_q[j]);
                 acc = __dp4a(w, v, acc);
             }
 #else

--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
@@ -4,15 +4,17 @@
 #include "traccc/definitions/qualifiers.hpp"
 
 // ------------------------------------------------------------
-// ①  真正放在「CUDA 常量記憶體」的權重；在 Host 端就是一般 const 陣列
+// ①  Weights stored in global memory for GPU execution;
+//    on the host they act as regular constant arrays
 // ------------------------------------------------------------
 
 namespace traccc::fitting::detail {
 
 // ------------------------------------------------------------
-// ①  真正放在「CUDA 常量記憶體」的權重；在 Host 端就是一般 const 陣列
+// ①  Weights stored in global memory for GPU execution;
+//    on the host they act as regular constant arrays
 // ------------------------------------------------------------
-TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline std::int8_t W0[1920] = {
+TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W0[1920] = {
     0, -3, 3, -5, 2, -2, 5, -6, 1, -2, 4, -4, 2, -1, 6, -6, 0, -3, 4, -4, 2, -1,
     5, -5, 1, -2, 4, -4, 3, 0,  6, -6, 0, -3, 3, -5, 2, -1, 5, -5, 1, -2, 4, -4,
     3, -1, 6, -6, 1, -3, 4, -4, 2, -1, 5, -5, 1, -2, 5, -3, 3, 0,  6, -6, 0, -3,
@@ -103,7 +105,7 @@ TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline std::int8_t W0[1920] = {
     5, -3, 3, 0,  6, -6,
 };
 
-TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline std::int8_t W1[512] = {
+TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W1[512] = {
     1, -2, 4, -4, 2, -1, 6, -6, 0, -3, 4, -4, 2, -1, 5, -5, 1, -2, 4, -3, 3, 0,
     6, -6, 0, -3, 3, -4, 2, -1, 5, -5, 1, -2, 4, -4, 3, -1, 6, -6, 1, -2, 4, -4,
     2, -1, 5, -5, 1, -2, 5, -3, 3, 0,  6, -6, 0, -3, 3, -5, 2, -1, 5, -5, 1, -2,
@@ -130,7 +132,7 @@ TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline std::int8_t W1[512] = {
     3, -5, 2, -2, 5, -5,
 };
 
-TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline std::int8_t W2[192] = {
+TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W2[192] = {
     0, -3, 3, -5, 2, -1, 5, -5, 1, -2, 4, -4, 2, -1, 6, -6, 1, -3, 4, -4, 2, -1,
     5, -5, 1, -2, 4, -3, 3, 0,  6, -6, 0, -3, 3, -4, 2, -1, 5, -5, 1, -2, 4, -4,
     3, 0,  6, -6, 1, -2, 4, -4, 2, -1, 5, -5, 1, -2, 5, -3, 3, 0,  6, -6, 0, -3,


### PR DESCRIPTION
## Summary
- move Kalman predictor weights from constant to global memory
- load weights via `__ldg` to avoid constant memory divergence

## Testing
- `cmake --preset base-fp32 -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6848320d180c8320b4f71ef3547af174