### PR TITLE
Use constant memory qualifiers for GRU weights

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
@@ -14,7 +14,7 @@ namespace traccc::fitting::detail {
 // ①  Weights stored in global memory for GPU execution;
 //    on the host they act as regular constant arrays
 // ------------------------------------------------------------
-TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W0[1920] = {
+TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const std::int8_t W0[1920] = {
     0, -3, 3, -5, 2, -2, 5, -6, 1, -2, 4, -4, 2, -1, 6, -6, 0, -3, 4, -4, 2, -1,
     5, -5, 1, -2, 4, -4, 3, 0,  6, -6, 0, -3, 3, -5, 2, -1, 5, -5, 1, -2, 4, -4,
     3, -1, 6, -6, 1, -3, 4, -4, 2, -1, 5, -5, 1, -2, 5, -3, 3, 0,  6, -6, 0, -3,
@@ -105,7 +105,7 @@ TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W0[1920] = {
     5, -3, 3, 0,  6, -6,
 };
 
-TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W1[512] = {
+TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const std::int8_t W1[512] = {
     1, -2, 4, -4, 2, -1, 6, -6, 0, -3, 4, -4, 2, -1, 5, -5, 1, -2, 4, -3, 3, 0,
     6, -6, 0, -3, 3, -4, 2, -1, 5, -5, 1, -2, 4, -4, 3, -1, 6, -6, 1, -2, 4, -4,
     2, -1, 5, -5, 1, -2, 5, -3, 3, 0,  6, -6, 0, -3, 3, -5, 2, -1, 5, -5, 1, -2,
@@ -132,7 +132,7 @@ TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W1[512] = {
     3, -5, 2, -2, 5, -5,
 };
 
-TRACCC_DEVICE TRACCC_ALIGN(4) inline const std::int8_t W2[192] = {
+TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const std::int8_t W2[192] = {
     0, -3, 3, -5, 2, -1, 5, -5, 1, -2, 4, -4, 2, -1, 6, -6, 1, -3, 4, -4, 2, -1,
     5, -5, 1, -2, 4, -3, 3, 0,  6, -6, 0, -3, 3, -4, 2, -1, 5, -5, 1, -2, 4, -4,
     3, 0,  6, -6, 1, -2, 4, -4, 2, -1, 5, -5, 1, -2, 5, -3, 3, 0,  6, -6, 0, -3,


### PR DESCRIPTION
## Summary
- place GRU weight arrays in constant memory

## Testing
- `cmake -B build -S . -G Ninja -DTRACCC_BUILD_CUDA=ON -DVECMEM_BUILD_CUDA_LIBRARY=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6848366982808320b56e51b08a5c14ae