### PR TITLE
Add GRU training data collection

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -46,8 +46,10 @@ traccc_add_library( traccc_core core TYPE SHARED
   "include/traccc/utils/seed_generator.hpp"
   "include/traccc/utils/subspace.hpp"
   "include/traccc/utils/logging.hpp"
+  "include/traccc/utils/gru_training_logger.hpp"
   "include/traccc/utils/prob.hpp"
   "src/utils/logging.cpp"
+  "src/utils/gru_training_logger.cpp"
   # Clusterization algorithmic code.
   "include/traccc/clusterization/details/sparse_ccl.hpp"
   "include/traccc/clusterization/impl/sparse_ccl.ipp"

--- a/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
+++ b/core/include/traccc/fitting/kalman_filter/gain_matrix_updater.hpp
@@ -12,6 +12,7 @@
 #include "traccc/definitions/track_parametrization.hpp"
 #include "traccc/edm/track_state.hpp"
 #include "traccc/fitting/status_codes.hpp"
+#include "traccc/utils/gru_training_logger.hpp"
 
 // Detray inlcude(s)
 #include <detray/geometry/shapes/line.hpp>
@@ -111,6 +112,37 @@ struct gain_matrix_updater {
         // Kalman gain matrix
         const matrix_type<6, D> K =
             predicted_cov * matrix::transpose(H) * matrix::inverse(M);
+
+#ifdef TRACCC_ENABLE_GRU_DATA_COLLECTION
+        {
+            std::vector<traccc::scalar> row;
+            row.reserve(6 + 36 + 6 * D + D * D + 6 * D);
+            for (size_type i = 0; i < 6; ++i) {
+                row.push_back(getter::element(predicted_vec, i, 0));
+            }
+            for (size_type r = 0; r < 6; ++r) {
+                for (size_type c = 0; c < 6; ++c) {
+                    row.push_back(getter::element(predicted_cov, r, c));
+                }
+            }
+            for (size_type r = 0; r < D; ++r) {
+                for (size_type c = 0; c < 6; ++c) {
+                    row.push_back(getter::element(H, r, c));
+                }
+            }
+            for (size_type r = 0; r < D; ++r) {
+                for (size_type c = 0; c < D; ++c) {
+                    row.push_back(getter::element(V, r, c));
+                }
+            }
+            for (size_type r = 0; r < 6; ++r) {
+                for (size_type c = 0; c < D; ++c) {
+                    row.push_back(getter::element(K, r, c));
+                }
+            }
+            gru_training_logger::write_row(row);
+        }
+#endif
 
         // Calculate the filtered track parameters
         const matrix_type<6, 1> filtered_vec =

--- a/core/include/traccc/utils/gru_training_logger.hpp
+++ b/core/include/traccc/utils/gru_training_logger.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <fstream>
+#include <mutex>
+#include <vector>
+#include "traccc/definitions/primitives.hpp"
+
+namespace traccc {
+
+class gru_training_logger {
+public:
+    static void write_row(const std::vector<traccc::scalar>& values);
+
+private:
+    static std::ofstream& stream();
+    static std::mutex& mutex();
+};
+
+}  // namespace traccc

--- a/core/src/utils/gru_training_logger.cpp
+++ b/core/src/utils/gru_training_logger.cpp
@@ -1,0 +1,27 @@
+#include "traccc/utils/gru_training_logger.hpp"
+
+namespace traccc {
+
+std::ofstream& gru_training_logger::stream() {
+    static std::ofstream s("gru_training_data.csv");
+    return s;
+}
+
+std::mutex& gru_training_logger::mutex() {
+    static std::mutex m;
+    return m;
+}
+
+void gru_training_logger::write_row(const std::vector<traccc::scalar>& values) {
+    std::lock_guard<std::mutex> lock(mutex());
+    std::ofstream& out = stream();
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        out << values[i];
+        if (i + 1 != values.size()) {
+            out << ',';
+        }
+    }
+    out << '\n';
+}
+
+}  // namespace traccc


### PR DESCRIPTION
## Summary
- provide `gru_training_logger` for recording Kalman filter training data
- log predicted vectors, covariances, projector matrix, measurement covariance
  and Kalman gain when `TRACCC_ENABLE_GRU_DATA_COLLECTION` is defined

## Testing
- `cmake -S . -B build -G Ninja -DTRACCC_BUILD_TESTING=OFF -DTRACCC_BUILD_EXAMPLES=OFF -DTRACCC_BUILD_CUDA=OFF -DTRACCC_BUILD_SYCL=OFF -DTRACCC_BUILD_ALPAKA=OFF -DTRACCC_USE_ROOT=OFF`
- `cmake --build build --target traccc_core -j4` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68484fb9d55c8320887362d27571abcb