### PR TITLE
Use R2 as loss for gain model

### DIFF
--- a/extras/mlp_gain_training/README.md
+++ b/extras/mlp_gain_training/README.md
@@ -12,6 +12,6 @@ The workflow implements two stages:
 
 The resulting model architecture matches the implementation in
 `kalman_int8_gru_gain_predictor.hpp` (hidden sizes 32 and 16).
-Training optimises the root mean squared error (RMSE) between the predicted
-and true Kalman gain. Run the script with `python3 train_mlp_gain.py --help`
-for usage information.
+Training minimises ``1 - R^2`` so as to maximise the coefficient of
+determination between the predicted and true Kalman gain. Run the script with
+`python3 train_mlp_gain.py --help` for usage information.


### PR DESCRIPTION
## Summary
- minimize `1 - R^2` when training the Kalman gain MLP
- record R^2 based metrics and mention it in the training README

## Testing
- `python3 -m py_compile extras/mlp_gain_training/train_mlp_gain.py`
- `python3 extras/mlp_gain_training/train_mlp_gain.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6849971b15248320bd22288d8e864646