### PR TITLE
Fix compilation for options examples

### DIFF
--- a/examples/options/src/accelerator.cpp
+++ b/examples/options/src/accelerator.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include <sstream>
 
 namespace traccc::opts {
 
@@ -26,7 +26,7 @@ std::unique_ptr<configuration_printable> accelerator::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Compare with CPU output", std::format("{}", compare_with_cpu)));
+        "Compare with CPU output", compare_with_cpu ? "true" : "false"));
 
     return cat;
 }

--- a/examples/options/src/detector.cpp
+++ b/examples/options/src/detector.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include <sstream>
 
 namespace traccc::opts {
 
@@ -50,7 +50,7 @@ std::unique_ptr<configuration_printable> detector::as_printable() const {
     cat->add_child(std::make_unique<configuration_kv_pair>("Surface grid file",
                                                            grid_file));
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Use detray detector", std::format("{}", use_detray_detector)));
+        "Use detray detector", use_detray_detector ? "true" : "false"));
     cat->add_child(std::make_unique<configuration_kv_pair>("Digitization file",
                                                            digitization_file));
 

--- a/examples/options/src/input_data.cpp
+++ b/examples/options/src/input_data.cpp
@@ -11,7 +11,6 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
 #include <sstream>
 #include <stdexcept>
 
@@ -66,7 +65,7 @@ std::unique_ptr<configuration_printable> input_data::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Use ACTS geometry source", std::format("{}", use_acts_geom_source)));
+        "Use ACTS geometry source", use_acts_geom_source ? "true" : "false"));
     std::ostringstream format_ss;
     format_ss << format;
     cat->add_child(std::make_unique<configuration_kv_pair>("Input data format",

--- a/examples/options/src/performance.cpp
+++ b/examples/options/src/performance.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include <sstream>
 
 namespace traccc::opts {
 
@@ -26,7 +26,7 @@ std::unique_ptr<configuration_printable> performance::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Run performance checks", std::format("{}", run)));
+        "Run performance checks", run ? "true" : "false"));
 
     return cat;
 }

--- a/examples/options/src/throughput.cpp
+++ b/examples/options/src/throughput.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include <sstream>
 
 namespace traccc::opts {
 
@@ -51,7 +51,7 @@ std::unique_ptr<configuration_printable> throughput::as_printable() const {
         std::make_unique<configuration_kv_pair>("Log file", log_file));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Deterministic ordering",
-        std::format("{}", deterministic_event_order)));
+        deterministic_event_order ? "true" : "false"));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Random seed",
         random_seed == 0 ? "time-based" : std::to_string(random_seed)));

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -12,8 +12,8 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
 #include <limits>
+#include <sstream>
 
 namespace traccc::opts {
 
@@ -131,10 +131,10 @@ std::unique_ptr<configuration_printable> track_propagation::as_printable()
                              " mm"));
     cat_tsp->add_child(std::make_unique<configuration_kv_pair>(
         "Enable Bethe energy loss",
-        std::format("{}", m_config.stepping.use_mean_loss)));
+        m_config.stepping.use_mean_loss ? "true" : "false"));
     cat_tsp->add_child(std::make_unique<configuration_kv_pair>(
         "Enable covariance transport",
-        std::format("{}", m_config.stepping.do_covariance_transport)));
+        m_config.stepping.do_covariance_transport ? "true" : "false"));
 
     if (m_config.stepping.do_covariance_transport) {
         auto cat_cov =
@@ -142,10 +142,10 @@ std::unique_ptr<configuration_printable> track_propagation::as_printable()
 
         cat_cov->add_child(std::make_unique<configuration_kv_pair>(
             "Enable energy loss gradient",
-            std::format("{}", m_config.stepping.use_eloss_gradient)));
+            m_config.stepping.use_eloss_gradient ? "true" : "false"));
         cat_cov->add_child(std::make_unique<configuration_kv_pair>(
             "Enable B-field gradient",
-            std::format("{}", m_config.stepping.use_field_gradient)));
+            m_config.stepping.use_field_gradient ? "true" : "false"));
 
         cat_tsp->add_child(std::move(cat_cov));
     }

--- a/examples/options/src/truth_finding.cpp
+++ b/examples/options/src/truth_finding.cpp
@@ -7,7 +7,7 @@
 
 #include "traccc/options/truth_finding.hpp"
 
-#include <format>
+#include <sstream>
 
 #include "traccc/definitions/common.hpp"
 #include "traccc/examples/utils/printable.hpp"
@@ -28,8 +28,10 @@ void truth_finding::read(const boost::program_options::variables_map &) {
 std::unique_ptr<configuration_printable> truth_finding::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
-    cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Minimum pT", std::format("{} GeV", m_min_pt / unit<float>::GeV)));
+    std::ostringstream ss;
+    ss << (m_min_pt / unit<float>::GeV) << " GeV";
+    cat->add_child(
+        std::make_unique<configuration_kv_pair>("Minimum pT", ss.str()));
 
     return cat;
 }


### PR DESCRIPTION
## Summary
- eliminate usage of `std::format` in options example sources
- represent boolean options with string literals and use string streams for floats

## Testing
- `pre-commit run --files examples/options/src/accelerator.cpp examples/options/src/detector.cpp examples/options/src/input_data.cpp examples/options/src/performance.cpp examples/options/src/throughput.cpp examples/options/src/track_propagation.cpp examples/options/src/truth_finding.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684d0692aea88320a89c43e2a0ea17b4