### PR TITLE
Fix std::format compilation issues

### DIFF
--- a/core/include/traccc/utils/format.hpp
+++ b/core/include/traccc/utils/format.hpp
@@ -1,0 +1,21 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if __has_include(<format>) && defined(__cpp_lib_format)
+#include <format>
+namespace traccc {
+using std::format;
+}  // namespace traccc
+#else
+#include <fmt/format.h>
+namespace traccc {
+using fmt::format;
+}  // namespace traccc
+#endif
+

--- a/examples/options/src/accelerator.cpp
+++ b/examples/options/src/accelerator.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 
 namespace traccc::opts {
 
@@ -26,7 +26,7 @@ std::unique_ptr<configuration_printable> accelerator::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Compare with CPU output", std::format("{}", compare_with_cpu)));
+        "Compare with CPU output", traccc::format("{}", compare_with_cpu)));
 
     return cat;
 }

--- a/examples/options/src/detector.cpp
+++ b/examples/options/src/detector.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 
 namespace traccc::opts {
 
@@ -50,7 +50,7 @@ std::unique_ptr<configuration_printable> detector::as_printable() const {
     cat->add_child(std::make_unique<configuration_kv_pair>("Surface grid file",
                                                            grid_file));
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Use detray detector", std::format("{}", use_detray_detector)));
+        "Use detray detector", traccc::format("{}", use_detray_detector)));
     cat->add_child(std::make_unique<configuration_kv_pair>("Digitization file",
                                                            digitization_file));
 

--- a/examples/options/src/input_data.cpp
+++ b/examples/options/src/input_data.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 #include <sstream>
 #include <stdexcept>
 
@@ -66,7 +66,7 @@ std::unique_ptr<configuration_printable> input_data::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Use ACTS geometry source", std::format("{}", use_acts_geom_source)));
+        "Use ACTS geometry source", traccc::format("{}", use_acts_geom_source)));
     std::ostringstream format_ss;
     format_ss << format;
     cat->add_child(std::make_unique<configuration_kv_pair>("Input data format",

--- a/examples/options/src/performance.cpp
+++ b/examples/options/src/performance.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 
 namespace traccc::opts {
 
@@ -26,7 +26,7 @@ std::unique_ptr<configuration_printable> performance::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Run performance checks", std::format("{}", run)));
+        "Run performance checks", traccc::format("{}", run)));
 
     return cat;
 }

--- a/examples/options/src/throughput.cpp
+++ b/examples/options/src/throughput.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 
 namespace traccc::opts {
 
@@ -51,7 +51,7 @@ std::unique_ptr<configuration_printable> throughput::as_printable() const {
         std::make_unique<configuration_kv_pair>("Log file", log_file));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Deterministic ordering",
-        std::format("{}", deterministic_event_order)));
+        traccc::format("{}", deterministic_event_order)));
     cat->add_child(std::make_unique<configuration_kv_pair>(
         "Random seed",
         random_seed == 0 ? "time-based" : std::to_string(random_seed)));

--- a/examples/options/src/track_fitting.cpp
+++ b/examples/options/src/track_fitting.cpp
@@ -12,7 +12,7 @@
 #include "traccc/utils/particle.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 
 namespace traccc::opts {
 

--- a/examples/options/src/track_propagation.cpp
+++ b/examples/options/src/track_propagation.cpp
@@ -12,7 +12,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 #include <limits>
 
 namespace traccc::opts {
@@ -131,10 +131,10 @@ std::unique_ptr<configuration_printable> track_propagation::as_printable()
                              " mm"));
     cat_tsp->add_child(std::make_unique<configuration_kv_pair>(
         "Enable Bethe energy loss",
-        std::format("{}", m_config.stepping.use_mean_loss)));
+        traccc::format("{}", m_config.stepping.use_mean_loss)));
     cat_tsp->add_child(std::make_unique<configuration_kv_pair>(
         "Enable covariance transport",
-        std::format("{}", m_config.stepping.do_covariance_transport)));
+        traccc::format("{}", m_config.stepping.do_covariance_transport)));
 
     if (m_config.stepping.do_covariance_transport) {
         auto cat_cov =
@@ -142,10 +142,10 @@ std::unique_ptr<configuration_printable> track_propagation::as_printable()
 
         cat_cov->add_child(std::make_unique<configuration_kv_pair>(
             "Enable energy loss gradient",
-            std::format("{}", m_config.stepping.use_eloss_gradient)));
+            traccc::format("{}", m_config.stepping.use_eloss_gradient)));
         cat_cov->add_child(std::make_unique<configuration_kv_pair>(
             "Enable B-field gradient",
-            std::format("{}", m_config.stepping.use_field_gradient)));
+            traccc::format("{}", m_config.stepping.use_field_gradient)));
 
         cat_tsp->add_child(std::move(cat_cov));
     }

--- a/examples/options/src/track_resolution.cpp
+++ b/examples/options/src/track_resolution.cpp
@@ -11,7 +11,7 @@
 #include "traccc/examples/utils/printable.hpp"
 
 // System include(s).
-#include <format>
+#include "traccc/utils/format.hpp"
 
 namespace traccc::opts {
 

--- a/examples/options/src/truth_finding.cpp
+++ b/examples/options/src/truth_finding.cpp
@@ -7,7 +7,7 @@
 
 #include "traccc/options/truth_finding.hpp"
 
-#include <format>
+#include "traccc/utils/format.hpp"
 
 #include "traccc/definitions/common.hpp"
 #include "traccc/examples/utils/printable.hpp"
@@ -29,7 +29,7 @@ std::unique_ptr<configuration_printable> truth_finding::as_printable() const {
     auto cat = std::make_unique<configuration_category>(m_description);
 
     cat->add_child(std::make_unique<configuration_kv_pair>(
-        "Minimum pT", std::format("{} GeV", m_min_pt / unit<float>::GeV)));
+        "Minimum pT", traccc::format("{} GeV", m_min_pt / unit<float>::GeV)));
 
     return cat;
 }


### PR DESCRIPTION
## Summary
- introduce `format.hpp` to provide a fallback to `fmt::format`
- use `traccc::format` in options examples

## Testing
- `g++ -std=c++20 -Icore/include -Iexamples/options/include -Iexamples/utils/include -c examples/options/src/performance.cpp -o /tmp/performance.o`

------
https://chatgpt.com/codex/tasks/task_e_684d13360d3c8320a17dd13a225a6091