### PR TITLE
Add bias arrays to int8 GRU predictor

### DIFF
--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor.hpp
@@ -96,7 +96,9 @@ struct kalman_int8_gru_gain_predictor {
         TRACCC_ALIGN(16) qscalar h0_q[HiddenSize1];
         TRACCC_PRAGMA_UNROLL
         for (size_type i = 0; i < HiddenSize1; ++i) {
-            accum_t acc = 0;
+            accum_t acc = static_cast<accum_t>(
+                kalman_int8_gru_gain_predictor_weights<algebra_t, D>::B0[i] *
+                kScale * kScale);
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 610)
             const auto* W =
 #ifdef __CUDA_ARCH__
@@ -128,7 +130,9 @@ struct kalman_int8_gru_gain_predictor {
         TRACCC_ALIGN(16) qscalar h1_q[HiddenSize2];
         TRACCC_PRAGMA_UNROLL
         for (size_type i = 0; i < HiddenSize2; ++i) {
-            accum_t acc = 0;
+            accum_t acc = static_cast<accum_t>(
+                kalman_int8_gru_gain_predictor_weights<algebra_t, D>::B1[i] *
+                kScale * kScale);
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 610)
             const auto* W =
 #ifdef __CUDA_ARCH__
@@ -165,7 +169,9 @@ struct kalman_int8_gru_gain_predictor {
             TRACCC_PRAGMA_UNROLL
         for (size_type c = 0; c < D; ++c) {
             const size_type o = r * D + c;
-            accum_t acc = 0;
+            accum_t acc = static_cast<accum_t>(
+                kalman_int8_gru_gain_predictor_weights<algebra_t, D>::B2[o] *
+                kScale * kScale);
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 610)
             const auto* W =
 #ifdef __CUDA_ARCH__

--- a/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
+++ b/core/include/traccc/fitting/kalman_filter/kalman_int8_gru_gain_predictor_weights.hpp
@@ -20,6 +20,12 @@ TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const std::int8_t W1[2048] = {0};
 
 TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const std::int8_t W2[640] = {0};
 
+TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const float B0[32] = {0.f};
+
+TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const float B1[64] = {0.f};
+
+TRACCC_DEVICE_CONSTANT TRACCC_ALIGN(4) inline const float B2[10] = {0.f};
+
 }  // namespace traccc::fitting::detail
 
 // ------------------------------------------------------------
@@ -33,5 +39,8 @@ struct kalman_int8_gru_gain_predictor_weights {
     static constexpr const auto& W0 = detail::W0;
     static constexpr const auto& W1 = detail::W1;
     static constexpr const auto& W2 = detail::W2;
+    static constexpr const auto& B0 = detail::B0;
+    static constexpr const auto& B1 = detail::B1;
+    static constexpr const auto& B2 = detail::B2;
 };
 }  // namespace traccc::fitting


### PR DESCRIPTION
## Summary
- add FP32 bias arrays in the weights header
- include these biases in all three fully-connected layers of `kalman_int8_gru_gain_predictor`

## Testing
- `cmake --preset host-fp32 -S . -B build` *(fails: Could NOT find TBB)*

------
https://chatgpt.com/codex/tasks/task_e_685667c9021c8320af98a87a8d031e31